### PR TITLE
wip on transformation used for import of Eagle data to Perseids

### DIFF
--- a/wikixml to perseids/eagle-xml-perseids.xsl
+++ b/wikixml to perseids/eagle-xml-perseids.xsl
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This transform is meant to run on the output of an API request to the Eagle MediaWiki to
+     create a new translation for editing in Perseids.  
+     
+     Params:
+     
+     $agent: Will be set by Perseids to the agreed URI identifier for the Eagle Agent for Perseids
+     $id : Will be set by Perseids to the Eagle Wiki identifer that was retrieved
+     $current_user: will be set by Perseids to the URI for the current user
+     $filter: for an edit of an existing translation: set to the id of the Claim on which the new
+              translation is to be based.
+     $lang: for a new empty translation: if the $filter param is not supplied, the $lang param must be, and it should be set to the language
+             code for the new translation, which will not be pre-populated with any existing translation text.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    <xsl:output method="xml" indent="yes"></xsl:output>
+    <xsl:param name="agent" select="'http://www.eagle-network.eu'"/>
+    <xsl:param name="id"/>
+    <xsl:param name="current_user"/>
+    <xsl:param name="filter"/>
+    <xsl:param name="lang"/>
+    <xsl:template match="/">
+    <xsl:variable name="iteminwiki" select="//entity[1]"/>
+    <xsl:variable name="ctsurn">
+        <xsl:choose>
+           <xsl:when test="$iteminwiki//property[@id='p3']">
+               <xsl:value-of select="concat('urn:cts:pdlepi:eagle.tm', $iteminwiki//property[@id='p3']//datavalue/@value)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!--only items with TM ids are supported for Perseids-EAGLE integration -->
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="itemstoedit">
+        <xsl:choose>
+            <xsl:when test="$filter">
+                <xsl:for-each select="$iteminwiki//claim[@id=$filter]">
+                    <xsl:variable name="textlang">
+                        <xsl:choose>
+                            <xsl:when test="../@id = 'p11'">en</xsl:when>
+                            <xsl:when test="../@id = 'p12'">de</xsl:when>
+                            <xsl:when test="../@id = 'p13'">it</xsl:when>
+                            <xsl:when test="../@id = 'p14'">es</xsl:when>
+                            <xsl:when test="../@id = 'p15'">fr</xsl:when>
+                            <xsl:when test="../@id= 'p19'">hu</xsl:when>
+                            <xsl:when test="../@id = 'p57'">hr</xsl:when>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:element name="wrapper">
+                        <xsl:attribute name="xml:lang"><xsl:value-of select="$textlang"/></xsl:attribute>
+                        <xsl:copy-of select="."></xsl:copy-of>
+                    </xsl:element>
+                </xsl:for-each>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:variable>
+     
+    <create urn="{$ctsurn}" pubtype="translation" type="EpiTransCTSIdentifier">
+        <xsl:choose>
+            <!-- if we don't have any items selected, create a new one -->
+            <xsl:when test="not($itemstoedit)">
+                <TEI xmlns="http://www.tei-c.org/ns/1.0">
+                    <xsl:call-template name="make_header">
+                        <xsl:with-param name="entity" select="$iteminwiki"/>
+                        <xsl:with-param name="claim" select="()"/>
+                        <xsl:with-param name="title" select="$iteminwiki//description[@language=$lang]/@value"/>
+                        <xsl:with-param name="ctsurn" select="$ctsurn"/>
+                        <xsl:with-param name="lang" select="$lang"/>
+                        <xsl:with-param name="default_license" select="$iteminwiki//property[@id='p25']//datavalue/@value"></xsl:with-param>
+                    </xsl:call-template>
+                    <text xml:lang="{$lang}">
+                        <body>
+                            <div xml:lang="{$lang}" type="translation" xml:space="preserve" n="{$ctsurn}">
+                                <ab></ab>
+                            </div>
+                        </body>
+                    </text>
+                </TEI>    
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:for-each select="$itemstoedit//claim">
+                    <xsl:variable name="textlang" select="parent::wrapper/@xml:lang"/>
+                    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+                        <xsl:call-template name="make_header">
+                            <xsl:with-param name="entity" select="$iteminwiki"/>
+                            <xsl:with-param name="claim" select="."/>
+                            <xsl:with-param name="title" select="$iteminwiki//description[@language=$textlang]/@value"/>
+                            <xsl:with-param name="ctsurn" select="$ctsurn"/>
+                            <xsl:with-param name="lang" select="$textlang"/>
+                            <xsl:with-param name="default_license" select="$iteminwiki//property[@id='p25']//datavalue/@value"></xsl:with-param>
+                        </xsl:call-template>
+                        <text xml:lang="{$textlang}">
+                            <body>
+                                <div xml:lang="{$textlang}" type="translation" xml:space="preserve" n="{$ctsurn}">
+                                    <ab><xsl:value-of select=".//mainsnak/datavalue/@value"/></ab>
+                                </div>
+                            </body>
+                        </text>
+                    </TEI>    
+                </xsl:for-each>
+            </xsl:otherwise>
+        </xsl:choose>
+    </create>
+</xsl:template>
+    
+    <xsl:template name="make_header">
+        <xsl:param name="entity"/>
+        <xsl:param name="claim"/>
+        <xsl:param name="title"/>
+        <xsl:param name="lang"/>
+        <xsl:param name="ctsurn"/>
+        <xsl:param name="default_license"/>
+        <!--  TODO verify how licenses are specified per translation (-->        
+        <xsl:variable name="license">
+            <xsl:choose>
+                <xsl:when test="$claim//property[@id='p25']">
+                    <xsl:value-of select="$claim//property[@id='p25']//datavalue/@value"/>
+                </xsl:when>
+                <xsl:otherwise><xsl:value-of select="$default_license"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable> 
+        <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
+                <fileDesc>
+                    <titleStmt>
+                        <title xml:lang="{$lang}"><xsl:value-of select="$title"/></title>
+                            <xsl:for-each select="$claim//references//property[@id='p21']/snak">
+                                <editor role="translator" xml:lang="{$lang}">
+                                <xsl:value-of select="datavalue/@value"/>
+                                </editor>
+                            </xsl:for-each>    
+                        <editor role="translator" xml:lang="en">
+                            <xsl:value-of select="$current_user"/>
+                        </editor>
+                      </titleStmt>
+                    <publicationStmt>
+                        <authority>Europeana Network of Ancient Greek and Latin Epigraphy</authority>
+                        <idno type="urn:cts">
+                            <xsl:value-of select="$ctsurn"/></idno>
+                        <xsl:call-template name="make_ids">
+                            <xsl:with-param name="iteminwiki" select="$entity"/>
+                        </xsl:call-template>
+                        <availability>
+                            <p>
+                                <ref type="license" target="{$license}"/>
+                            </p>
+                        </availability>
+                        <distributor><xsl:value-of select="$agent"/></distributor>
+                    </publicationStmt>
+                    <sourceDesc>
+                        <xsl:choose>
+                            <xsl:when test="$claim//references//property[@id='p54']">
+                                <xsl:for-each select="$claim//references//property[@id='p54']/snak">
+                                    <p><xsl:value-of select="datavalue/@value"/></p>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:otherwise><p/></xsl:otherwise>
+                        </xsl:choose>
+                    </sourceDesc>
+                </fileDesc>
+                <profileDesc>
+                    <langUsage>
+                        <language ident="en"/>
+                        <language ident="grc"/>
+                        <language ident="la"/>
+                        <language ident="fr"/>
+                        <language ident="de"/>
+                        <language ident="grc-Latn"/>
+                        <language ident="la-Grek"/>
+                        <language ident="cop"/>
+                    </langUsage>
+                </profileDesc>
+                <revisionDesc>
+                    <change who="{$current_user}">
+                        Imported from <xsl:value-of select="concat($agent,'/wiki/index.php/Item:',$id)"/>
+                    </change>
+                </revisionDesc>
+            </teiHeader>
+    </xsl:template>
+    
+    <xsl:template name="make_ids">
+        <xsl:param name="iteminwiki"/>
+        <!-- make the agent identifier idnos -->
+        <xsl:call-template name="make_idno">
+            <xsl:with-param name="type"><xsl:value-of select="$agent"/></xsl:with-param>
+            <xsl:with-param name="value"><xsl:value-of select="$id"></xsl:value-of></xsl:with-param>
+        </xsl:call-template>
+        <xsl:choose>
+            <xsl:when test="$iteminwiki//property[@id='p37']">
+                <xsl:call-template name="make_idno">
+                    <xsl:with-param name="type">EDB</xsl:with-param>
+                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p37']//datavalue/@value"/></xsl:with-param>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="$iteminwiki//property[@id='p24']">
+                        <xsl:call-template name="make_idno">
+                            <xsl:with-param name="type">EDH</xsl:with-param>
+                            <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p24']//datavalue/@value"/></xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:choose>
+                            <xsl:when test="$iteminwiki//property[@id='p38']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">EDR</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p38']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p22']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">HE</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p22']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p33']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">petrae</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p33']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p34']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">UEL</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p34']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p35']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">DAI</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p35']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p47']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">Last Statues of Antiquity</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p47']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p40']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">BSR - IRT</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p40']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p50']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">insAph</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p50']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>                            
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p48']"> 
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">ELTE</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p48']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>                     
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p51']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">AIO</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p51']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>         
+                                <xsl:text>AIO</xsl:text><xsl:value-of select="$iteminwiki//property[@id='p51']//datavalue/@value"/>
+                            </xsl:when>
+                            <xsl:when test="$iteminwiki//property[@id='p56']">
+                                <xsl:call-template name="make_idno">
+                                    <xsl:with-param name="type">phi</xsl:with-param>
+                                    <xsl:with-param name="value"><xsl:value-of select="$iteminwiki//property[@id='p56']//datavalue/@value"/></xsl:with-param>
+                                </xsl:call-template>         
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template name="make_idno">
+        <xsl:param name="type"/>
+        <xsl:param name="value"/>
+        <xsl:element name="idno" namespace="http://www.tei-c.org/ns/1.0">
+            <xsl:attribute name="type"><xsl:value-of select="$type"/></xsl:attribute>
+            <xsl:value-of select="$value"/>
+        </xsl:element>
+    </xsl:template>
+</xsl:stylesheet>

--- a/wikixml to perseids/samplenewit.xml
+++ b/wikixml to perseids/samplenewit.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<create urn="urn:cts:pdlepi:eagle.tm179252"
+        pubtype="translation"
+        type="EpiTransCTSIdentifier">
+   <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+         <fileDesc>
+            <titleStmt>
+               <title xml:lang="it"/>
+               <editor role="translator" xml:lang="en">http://data.perseus.org/users/Bridget%20Almas</editor>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Europeana Network of Ancient Greek and Latin Epigraphy</authority>
+               <idno type="urn:cts">urn:cts:pdlepi:eagle.tm179252</idno>
+               <idno type="http://www.eagle-network.eu"/>
+               <idno type="EDH">HD029889</idno>
+               <availability>
+                  <p>
+                     <ref type="license" target="http://creativecommons.org/licenses/by-sa/3.0/"/>
+                  </p>
+               </availability>
+               <distributor>http://www.eagle-network.eu</distributor>
+            </publicationStmt>
+            <sourceDesc>
+               <p/>
+            </sourceDesc>
+         </fileDesc>
+         <profileDesc>
+            <langUsage>
+               <language ident="en"/>
+               <language ident="grc"/>
+               <language ident="la"/>
+               <language ident="fr"/>
+               <language ident="de"/>
+               <language ident="grc-Latn"/>
+               <language ident="la-Grek"/>
+               <language ident="cop"/>
+            </langUsage>
+         </profileDesc>
+         <revisionDesc>
+            <change who="">
+                        Imported from http://www.eagle-network.eu/wiki/index.php/Item:</change>
+         </revisionDesc>
+      </teiHeader>
+      <text xml:lang="it">
+         <body>
+            <div xml:lang="it" type="translation" xml:space="preserve" n="urn:cts:pdlepi:eagle.tm179252">
+                                <ab/>
+                            </div>
+         </body>
+      </text>
+   </TEI>
+</create>

--- a/wikixml to perseids/sampleq5016.xml
+++ b/wikixml to perseids/sampleq5016.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<create urn="urn:cts:pdlepi:eagle.tm179252"
+        pubtype="translation"
+        type="EpiTransCTSIdentifier">
+   <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+         <fileDesc>
+            <titleStmt>
+               <title xml:lang="fr">Inscription votive</title>
+               <editor role="translator" xml:lang="fr">Ioan Piso</editor>
+               <editor role="translator" xml:lang="en">http://data.perseus.org/users/Bridget%20Almas</editor>
+            </titleStmt>
+            <publicationStmt>
+               <authority>Europeana Network of Ancient Greek and Latin Epigraphy</authority>
+               <idno type="urn:cts">urn:cts:pdlepi:eagle.tm179252</idno>
+               <idno type="http://www.eagle-network.eu">q5016</idno>
+               <idno type="EDH">HD029889</idno>
+               <availability>
+                  <p>
+                     <ref type="license" target="http://creativecommons.org/licenses/by-sa/3.0/"/>
+                  </p>
+               </availability>
+               <distributor>http://www.eagle-network.eu</distributor>
+            </publicationStmt>
+            <sourceDesc>
+               <p>I. Téglás, AÉrt 30, 19, p. 128-129, fig. 7 ( photo )</p>
+               <p>AE 19, 11</p>
+               <p>ILD 470</p>
+            </sourceDesc>
+         </fileDesc>
+         <profileDesc>
+            <langUsage>
+               <language ident="en"/>
+               <language ident="grc"/>
+               <language ident="la"/>
+               <language ident="fr"/>
+               <language ident="de"/>
+               <language ident="grc-Latn"/>
+               <language ident="la-Grek"/>
+               <language ident="cop"/>
+            </langUsage>
+         </profileDesc>
+         <revisionDesc>
+            <change who="http://data.perseus.org/users/Bridget%20Almas">
+                        Imported from http://www.eagle-network.eu/wiki/index.php/Item:q5016</change>
+         </revisionDesc>
+      </teiHeader>
+      <text xml:lang="fr">
+         <body>
+            <div xml:lang="fr" type="translation" xml:space="preserve" n="urn:cts:pdlepi:eagle.tm179252">
+                                    <ab>À Jupiter très bon ( et ) très grand. Petronius Marcianus s’est acquitté de ( son ) vœu de bon gré.</ab>
+                                </div>
+         </body>
+      </text>
+   </TEI>
+</create>


### PR DESCRIPTION
These files show the current wip on the import of Eagle data into Perseids.

We had said we wanted to support the following to use cases to start:

1) user submits an edit to an existing translation (thereby creating a new translation)
2) user submits a new translation

I think what these translate to in mediawiki "speak" are:

1) user submits a new claim to a existing item, based upon a previous claim
2) user submits a new claim to an existing item

(The sample links in the Eagle wiki right now include other functionality, such as adding licenses, identifiers, etc. I think these are out of scope for the moment.)

Here's what I've coded so far:

Case 1) :
Eagle wiki link to Perseids looks like:

`http://sosol.perseids.org/sosol/cts_publications/create_from_agent?agent=http://www.eagle-network.eu&id=<EAGLEENTITYID>&filter=<EAGLECLAIMID>`

e.g. so to edit the existing French translation in Q5016 it would be:

`http://sosol.perseids.org/sosol/cts_publications/create_from_agent?agent=http://www.eagle-network.eu&id=q5016&filter=q5016$B6CA42E3-D098-4A6F-9109-E879AE4B8E64`

(these won't work yet, as I have put the code up live -- we can set this up in a staging environment at an alternate url when we're ready to test)

Perseids retrieves the entire item using the following mediawiki api:
http://www.eagle-network.eu/wiki/api.php?action=wbgetentities&ids=q5016&format=xml

And uses eagle-xml-perseids.xsl to transform it to EpiDoc XML in Perseids.

User can make changes to the translation in Perseids, and then submit it to the Eagle Perseids Board.

Case 2) :
Eagle wiki link to Perseids looks like:

`http://sosol.perseids.org/sosol/cts_publications/create_from_agent?agent=http://www.eagle-network.eu&id=<EAGLEENTITYID>&lang=<LANG>`

e.g. so to add a new Italian translation to Q5016 it would be:

`http://sosol.perseids.org/sosol/cts_publications/create_from_agent?agent=http://www.eagle-network.eu&id=q5016&lang=it`

Perseids retrieves the entire item using the following mediawiki api:
http://www.eagle-network.eu/wiki/api.php?action=wbgetentities&ids=q5016&format=xml

And uses eagle-xml-perseids.xsl to transform it to EpiDoc XML in Perseids.

User enters their translation text in Perseids, and then submits it to the Eagle Perseids Board.

Assuming this is all okay so far, I have some questions on what the data sent in the final post of the approved version to the Eagle wiki would look like.
1. I think for either case, we are adding a new Claim to the Eagle wiki item, and I would use the wbsetclaim api call to do this.  Is this correct?
2. Other than the translation itself, the only new data added to the Eagle wiki at this point should be the CTS urn of the new translation, as assigned by Perseids (I think we will stick with CTS urns for now because progress on an alternate syntax has stalled somewhat).  So, sticking with the above example for case 1, the cts urn for the new french translation might be:
   `urn:cts:pdlepi:eagle.tm179252.pdl-fr-2014-1`
   If  desired, we could also add an item level property to represent the cts urn of the notional "work" identifier  
   `urn:cts:pdlepi:eagle.tm179252` 
   What is the right way to set  these as properties in the mediawiki claim and item respectively?
3. For case 1) should the source info, if present in the claim on which the new translation is being based, be carried over to the new translation?
4. Is my assumption correct that mediawiki will just automatically assign an id to the new claim in both of these cases, and is that what we want? Or do we want the new claim to be created in mediawiki first before the work starts on the item in Perseids?

Thanks!
Bridget
